### PR TITLE
add ability to select openai model

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.3",
+        "zustand": "^5.0.3",
       },
       "devDependencies": {
         "@types/eslint": "^8.56.10",
@@ -1389,6 +1390,8 @@
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.1", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w=="],
+
+    "zustand": ["zustand@5.0.3", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "superjson": "^2.2.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.23.3"
+    "zod": "^3.23.3",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@types/eslint": "^8.56.10",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,18 +2,20 @@ import { openai } from '@ai-sdk/openai';
 import { Message, streamText, appendResponseMessages, createIdGenerator } from 'ai';
 import { saveChat } from '../../../tools/chat-store';
 import { tools } from '~/ai/tools';
+import { Model } from '~/app/store/useModelStore';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
-  const { messages, id } = await req.json() as { 
+  const { messages, id, model } = await req.json() as { 
     messages: Message[]; 
     id: string;
+    model: Model;
   };
-
+  
   const result = streamText({
-    model: openai('gpt-4-turbo'),
+    model: openai(model),
     system: 'You are a helpful assistant.',
     messages,
     tools,

--- a/src/app/store/useModelStore.ts
+++ b/src/app/store/useModelStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+export type Model = 'gpt-4o' | 'gpt-4o-mini' | 'gpt-4-turbo' | 'gpt-3.5-turbo' 
+
+interface ModelStore {
+    model: Model,
+    resetModel: () => void,
+    updateModel: (newModel: Model) => void,
+}
+
+export const useModelStore = create<ModelStore>((set) => ({
+  model: 'gpt-4o',
+  resetModel: () => set({ model: 'gpt-4o' }),
+  updateModel: (newModel: Model) => set({ model: newModel }),
+}))

--- a/src/components/ui/chat-header.tsx
+++ b/src/components/ui/chat-header.tsx
@@ -1,22 +1,24 @@
 import React from 'react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectGroup, SelectLabel } from '~/components/ui/select'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar'
-// type Props = {}
+import { useModelStore, Model } from '~/app/store/useModelStore'
 
 export default function ChatHeader() {
+  const { model, updateModel } = useModelStore()
+
   return (
     <div className='flex justify-between items-center w-full bg-white mb-4'>
-        <Select>
+        <Select value={model} onValueChange={(value) => updateModel(value as Model)}>
             <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Select a model" />
             </SelectTrigger>
             <SelectContent>
                 <SelectGroup>
                 <SelectLabel>Models</SelectLabel>
-                <SelectItem value="gpt-4o">GPT-4o</SelectItem>
-                <SelectItem value="gpt-4o-mini">GPT-4o-mini</SelectItem>
-                <SelectItem value="gpt-3.5-turbo">GPT-3.5-turbo</SelectItem>
-                <SelectItem value="gpt-3.5-turbo-mini">GPT-3.5-turbo-mini</SelectItem>
+                <SelectItem value={"gpt-4o" as Model}>GPT-4o</SelectItem>
+                <SelectItem value={"gpt-4o-mini" as Model}>GPT-4o-mini</SelectItem>
+                <SelectItem value={"gpt-4-turbo" as Model}>GPT-4-turbo</SelectItem>
+                <SelectItem value={"gpt-3.5-turbo" as Model}>GPT-3.5-turbo</SelectItem>
                 </SelectGroup>
             </SelectContent>
         </Select>

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -5,16 +5,19 @@ import { createIdGenerator } from 'ai';
 import { ChatMessage } from './chat-message';
 import { MessageInput } from './message-input';
 import ChatHeader from './chat-header';
+import { useModelStore } from '~/app/store/useModelStore';
 
 export default function Chat({
   id,
   initialMessages,
 }: { id?: string | undefined; initialMessages?: Message[] } = {}) {
+  const { model } = useModelStore()
   const { input, handleInputChange, handleSubmit, messages } = useChat({
     maxSteps: 5,
     id,
     initialMessages, 
     sendExtraMessageFields: true,
+    body: { model },
     generateId: createIdGenerator({
       prefix: 'msgc',
       size: 16,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds model selection functionality using `zustand` for OpenAI models in chat application, updating API and UI components accordingly.
> 
>   - **Model Selection**:
>     - Introduces `useModelStore` in `useModelStore.ts` to manage OpenAI model selection with types `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, and `gpt-3.5-turbo`.
>     - Adds `zustand` as a dependency in `package.json` for state management.
>   - **API Changes**:
>     - Updates `POST` function in `route.ts` to accept `model` from request and use it in `streamText`.
>   - **UI Components**:
>     - Updates `ChatHeader` in `chat-header.tsx` to include a model selection dropdown using `useModelStore`.
>     - Modifies `Chat` component in `chat.tsx` to pass selected model to `useChat` hook.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fericwang-ai-chatbot&utm_source=github&utm_medium=referral)<sup> for 865a73eedf8d6169176f6f5bfead04e9ba1d7c27. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->